### PR TITLE
Improves UI and UX for Create and Login pages

### DIFF
--- a/public/css/login.css
+++ b/public/css/login.css
@@ -59,3 +59,10 @@
 	font-size: 14px;
 	cursor: pointer;
 }
+
+@media (min-width: 768px){
+	div.login div.row div.col-md-7 {
+		background: linear-gradient(218.04deg, #39a1f7 29.19%, #718cfb 81.17%)
+	}
+}
+

--- a/public/css/tstyle.css
+++ b/public/css/tstyle.css
@@ -1789,3 +1789,9 @@ img {
         margin-right: 0;
     }
 }
+
+@media (min-width: 768px){
+	div.register div.row div.col-md-7 {
+		background: linear-gradient(218.04deg, #39a1f7 29.19%, #718cfb 81.17%)
+	}
+}

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -63,7 +63,7 @@
                                 placeholder="{{ __('First name') }}"
                                 value = "{{ old('first_name') }}"
                                 class="d-block mt-4 mx-auto pr-2 @error('first_name') is-invalid @enderror"
-                                required autocomplete="name" autofocus
+                                required autocomplete="given-name" autofocus
                             />
                              @error('first_name')
                                     <span class="invalid-feedback" role="alert">
@@ -81,7 +81,7 @@
                                 placeholder="{{ __('Last name') }}"
                                 value ="{{ old('last_name') }}"
                                 class="d-block mt-4 mx-auto pr-2 @error('last_name') is-invalid @enderror"
-                                required autocomplete="name" autofocus
+                                required autocomplete="family-name" autofocus
                             />
 
                              @error('last_name')
@@ -100,7 +100,7 @@
                                 placeholder = "{{ __('E-Mail Address') }}"
                                 value="{{ old('email') }}"
                                 class="d-block mt-4 mx-auto pr-2 @error('email') is-invalid @enderror"
-                                required autocomplete="name" autofocus
+                                required autocomplete="email" autofocus
                             />
                              @error('email')
                                     <span class="invalid-feedback" role="alert" style="display: block;">
@@ -119,7 +119,7 @@
                                 id="phone"
                                 placeholder = "{{ __('Phone') }}"
                                 class="d-block mt-4 mx-auto pr-2 @error('email') is-invalid @enderror"
-                                required autocomplete="new-password" @error('phone') is-invalid @enderror"
+                                required autocomplete="tel" @error('phone') is-invalid @enderror"
                             />
                                    <span class="invalid-feedback" role="alert"  style="display: block;">
                                         <strong>{{ $errors->first('phone') }}</strong>


### PR DESCRIPTION
**Bug - Autocomplete for Create account Page.**
The initial Autocomplete of _name_ (full name) for _first name_, _last name_, and _email_. This makes the UX experience poor since the user still has to fill his first name, last name, and email manual.

**Bug - Create account Page image div no background color.**
The image background was different on a big screen, just white. Add the background color to make it better - better UI/UX.

**Bug - Sign in Page image div no background color.**
The image background was different on a big screen, just white. Add the background color to make it better - better UI/UX.

![autocomplete attributes](https://user-images.githubusercontent.com/19553200/66932177-1d775600-f02f-11e9-8681-fc931b6fc2ba.PNG)
![AutoFill - after](https://user-images.githubusercontent.com/19553200/66932179-1d775600-f02f-11e9-878d-ca3daf81f588.PNG)
![AutoFill -before](https://user-images.githubusercontent.com/19553200/66932180-1e0fec80-f02f-11e9-83b9-02d0151f47b3.PNG)
![bug-login-image](https://user-images.githubusercontent.com/19553200/66932181-1e0fec80-f02f-11e9-833c-688dbfaab907.PNG)
![bug-login-image-fixed](https://user-images.githubusercontent.com/19553200/66932183-1e0fec80-f02f-11e9-8c11-7b6b6ac59d77.PNG)
![bug-register-image](https://user-images.githubusercontent.com/19553200/66932185-1ea88300-f02f-11e9-809b-ec34879fdb93.PNG)
![bug-register-image-fixed](https://user-images.githubusercontent.com/19553200/66932186-1ea88300-f02f-11e9-9935-b05700eb523a.PNG)
