### PR TITLE
Makes My Story page Responsive (did some correction)

### DIFF
--- a/resources/views/mystories.blade.php
+++ b/resources/views/mystories.blade.php
@@ -27,22 +27,28 @@
     }
 
     .adjust-padding {
-        padding: 2rem 0 0 1rem;
+        padding: 2rem 0 0 0;
+    }
+
+    .applink {
+        margin: 5px 10px;
     }
 
     @media screen and (min-width: 551px){
-        h3 {
-            text-align:left;
-        }
-
-        p#createStory {
-            margin-left: 0;
+        .adjust-padding {
+            padding: 2rem 0 0 1rem;
         }
     }
 
     @media screen and (min-width: 750px){
         .adjust-padding {
             padding: 2rem 0 0 5rem;
+        }
+        h3 {
+            text-align:left;
+        }
+        p#createStory {
+            margin-left: 0;
         }
     }
 </style>
@@ -71,7 +77,7 @@
         @endif
     </div>
     <div class="col-md-12 d-flex cold p-0 ">
-        <div class="col-md-9 p-0">
+        <div class="col-md-7 col-lg-9 p-0">
             <div class="d-flex flex-column col-md-12  p-0">
                 <div class="d-flex flex-row flex-wrap">
                     @forelse ($stories as $story)
@@ -140,7 +146,7 @@
                 </div>
             </div>
         </div>
-        <div class="col-md-3 col-lg-3  catcs">
+        <div class="col-md-5 col-lg-3  catcs">
             <div class="d-flex flex-row col-md-12  ">
                 <div class="col-md-12 categories" id="category-drop">
                     <p>Search My Stories</p>


### PR DESCRIPTION
- Moves the button after the header 1 so You do not need to scroll all the way down to create a new story. _This makes it easy to place the draft(s) under published stories._

- Reduces the padding around the main (after the header) on small devices less than (750px).

- Made search and stories look better in terms of on a small screen.

![myStories Page-fix](https://user-images.githubusercontent.com/19553200/67002915-c4fa9400-f0d4-11e9-8723-799ff9455ad9.PNG)
![myStories Page](https://user-images.githubusercontent.com/19553200/67002916-c4fa9400-f0d4-11e9-81ad-b3e7a92eb593.PNG)